### PR TITLE
Add --force-exclude to args

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,6 +3,6 @@
   description: Source code spell checker, binary install
   language: conda
   entry: typos
-  args: []
+  args: [--force-exclude]
   types: [text]
   stages: [commit, merge-commit, push, manual]


### PR DESCRIPTION
Otherwise having something like this in `typos.toml` won't work

```
[files]
extend-exclude = [
    "test.txt"
]
```